### PR TITLE
Add incremental log parser and summary outputs

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -9,6 +9,25 @@
 - 统计交互或拾取物品的出现次数
 - 支持自定义日志文件路径
 
+## 增量解析器
+
+脚本 `incremental_parser.py` 可在日志追加时进行增量解析，并生成两份汇总文件：
+
+- `runs.jsonl`：逐条记录单次配置组运行情况，每条包含字段：
+  - `runId`：运行标识
+  - `configGroup`：配置组名称
+  - `start`、`end`：ISO8601 时间
+  - `duration`：运行耗时（秒）
+  - `products`：`{物品名称: 数量}` 映射
+- `summary.csv`：按配置组聚合的摘要表，字段：
+  - `config_group`
+  - `run_count`
+  - `total_duration_sec`
+  - `avg_duration_sec`
+  - `product_count`
+
+执行 `python incremental_parser.py` 将扫描 `$BETTERGI_PATH/log` 目录，解析新增日志行并更新以上文件。解析进度会记录在 `parser_state.json` 中，以便下次仅处理增量部分。
+
 ## 安装依赖
 
 ```bash

--- a/server/incremental_parser.py
+++ b/server/incremental_parser.py
@@ -1,0 +1,126 @@
+import os
+import json
+import re
+import csv
+from collections import defaultdict
+from datetime import datetime
+from dotenv import load_dotenv
+
+# 加载环境变量以获取日志路径
+load_dotenv()
+LOG_DIR = os.path.join(os.getenv("BETTERGI_PATH"), "log")
+
+STATE_FILE = os.path.join(os.path.dirname(__file__), "parser_state.json")
+RUNS_FILE = os.path.join(os.path.dirname(__file__), "runs.jsonl")
+SUMMARY_FILE = os.path.join(os.path.dirname(__file__), "summary.csv")
+
+# 事件匹配模式
+CONFIG_START_RE = re.compile(r"ConfigGroupStart group=(\S+) run=(\S+)")
+CONFIG_END_RE = re.compile(r"ConfigGroupEnd group=(\S+) run=(\S+)")
+PRODUCT_RE = re.compile(r"ProductEmitted name=(\S+) run=(\S+) count=(\d+)")
+TIMESTAMP_RE = re.compile(r"\[(\d{2}:\d{2}:\d{2}\.\d+)\]")
+
+
+def load_state():
+    if os.path.exists(STATE_FILE):
+        with open(STATE_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {"files": {}}
+
+
+def save_state(state):
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(state, f, ensure_ascii=False, indent=2)
+
+
+def parse_timestamp(date_prefix: str, line: str) -> datetime:
+    ts_match = TIMESTAMP_RE.search(line)
+    if not ts_match:
+        return None
+    time_part = ts_match.group(1)
+    dt = datetime.strptime(f"{date_prefix} {time_part}", "%Y%m%d %H:%M:%S.%f")
+    return dt
+
+
+def flush_run(run_id: str, run_data: dict, end_time: datetime):
+    run_data["end"] = end_time.isoformat()
+    run_data["duration"] = (end_time - run_data["start_dt"]).total_seconds()
+    run_data["start"] = run_data["start_dt"].isoformat()
+    del run_data["start_dt"]
+
+    with open(RUNS_FILE, "a", encoding="utf-8") as f:
+        f.write(json.dumps(run_data, ensure_ascii=False) + "\n")
+
+
+def write_summary():
+    summary = defaultdict(lambda: {"run_count": 0, "total_duration": 0, "product_count": 0})
+
+    if os.path.exists(RUNS_FILE):
+        with open(RUNS_FILE, "r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                run = json.loads(line)
+                group = run["configGroup"]
+                s = summary[group]
+                s["run_count"] += 1
+                s["total_duration"] += run.get("duration", 0)
+                s["product_count"] += sum(run.get("products", {}).values())
+
+    with open(SUMMARY_FILE, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["config_group", "run_count", "total_duration_sec", "avg_duration_sec", "product_count"])
+        for group, data in summary.items():
+            avg = data["total_duration"] / data["run_count"] if data["run_count"] else 0
+            writer.writerow([group, data["run_count"], int(data["total_duration"]), int(avg), data["product_count"]])
+
+
+def parse_logs():
+    state = load_state()
+    active_runs = {}
+
+    for filename in sorted(os.listdir(LOG_DIR)):
+        if not filename.startswith("better-genshin-impact") or not filename.endswith(".log"):
+            continue
+        date_part = filename.replace("better-genshin-impact", "").replace(".log", "")
+        file_path = os.path.join(LOG_DIR, filename)
+        offset = state["files"].get(filename, 0)
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            f.seek(offset)
+            for line in f:
+                start_match = CONFIG_START_RE.search(line)
+                if start_match:
+                    group, run_id = start_match.groups()
+                    ts = parse_timestamp(date_part, line)
+                    active_runs[run_id] = {
+                        "runId": run_id,
+                        "configGroup": group,
+                        "start_dt": ts,
+                        "products": defaultdict(int),
+                    }
+                    continue
+
+                prod_match = PRODUCT_RE.search(line)
+                if prod_match:
+                    name, run_id, count = prod_match.groups()
+                    if run_id in active_runs:
+                        active_runs[run_id]["products"][name] += int(count)
+                    continue
+
+                end_match = CONFIG_END_RE.search(line)
+                if end_match:
+                    group, run_id = end_match.groups()
+                    if run_id in active_runs:
+                        ts = parse_timestamp(date_part, line)
+                        flush_run(run_id, active_runs.pop(run_id), ts)
+                    continue
+
+            state["files"][filename] = f.tell()
+
+    save_state(state)
+    write_summary()
+
+
+if __name__ == "__main__":
+    parse_logs()


### PR DESCRIPTION
## Summary
- add incremental parser that tails BetterGI logs and emits run-level events to `runs.jsonl`
- generate per-config-group metrics in `summary.csv`
- document incremental parsing workflow and file formats

## Testing
- `python -m py_compile server/incremental_parser.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b95c863a048330a441cd62e6307477