### PR TITLE
Fix duration calculation across log gaps and add tests

### DIFF
--- a/mini/app.py
+++ b/mini/app.py
@@ -126,21 +126,20 @@ def parse_log(log_content, date_str):
                 # 表明是连续的事件，更新结束时间
                 current_end = current_time
             else:
-                # 表明是一段新的事件
+                # 表示与上一段存在较大间隔，需要先累加上一段时间
                 if delta <= 0:
                     logger.critical(
                         f"时间段错误,请检查。有关参数：{timestamp, details, date_str, current_start, current_end, delta}")
                 else:
-                    # 累加持续时间
-                    duration += int(delta)
+                    # 累加上一段持续时间
+                    duration += int((current_end - current_start).total_seconds())
                 # 开始新的时间段
                 current_start = current_time
                 current_end = current_time
 
     # 处理最后一段时间
-    if current_start and current_end and current_start != current_end:
-        delta = (current_end - current_start).total_seconds()
-        duration += int(delta)
+    if current_start and current_end:
+        duration += int((current_end - current_start).total_seconds())
 
     return {
         # 'type_count': type_count,

--- a/tests/test_duration.py
+++ b/tests/test_duration.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+# Ensure the repository root is on the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a dummy BETTERGI_PATH so mini.app can be imported
+os.environ.setdefault("BETTERGI_PATH", "/tmp")
+
+from mini.app import parse_log
+
+
+def test_duration_multiple_runs_with_gaps():
+    log_content = (
+        "[00:00:00.000] [INFO] TypeA\n"
+        "[00:02:00.000] [INFO] TypeA\n"
+        "[00:12:00.000] [INFO] TypeA\n"
+        "[00:15:00.000] [INFO] TypeA\n"
+    )
+
+    result = parse_log(log_content, "2024-01-01")
+
+    # 第一段持续2分钟，第二段持续3分钟，总计300秒
+    assert result["duration"] == 300
+
+
+def test_duration_three_runs_with_gaps():
+    log_content = (
+        "[00:00:00.000] [INFO] TypeA\n"
+        "[00:01:00.000] [INFO] TypeA\n"
+        "[00:07:00.000] [INFO] TypeA\n"
+        "[00:09:00.000] [INFO] TypeA\n"
+        "[00:15:00.000] [INFO] TypeA\n"
+        "[00:17:30.000] [INFO] TypeA\n"
+    )
+
+    result = parse_log(log_content, "2024-01-02")
+
+    # 三段持续时间分别为1分钟、2分钟和2.5分钟，总计330秒
+    assert result["duration"] == 330
+


### PR DESCRIPTION
## Summary
- fix segment duration calculation when large gaps exist in logs
- ensure final segment duration is included
- add tests for multi-run logs with gaps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b95daf5bd88330a674996e4bad2dfe