### PR TITLE
Configure logging for mini app

### DIFF
--- a/mini/app.py
+++ b/mini/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 from datetime import datetime
@@ -5,6 +6,10 @@ from collections import defaultdict
 from flask import Flask, jsonify, request, send_from_directory
 from dotenv import load_dotenv
 import pandas as pd
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 # 加载环境变量
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- Initialize standard logging in `mini/app.py`.
- Configure logging via `basicConfig` and create a module-level logger.
- Use the logger instance for critical errors to avoid runtime exceptions.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b95db0d598833098cd589b2668c4c2