### PR TITLE
feat: integrate API data with charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ Analyse_bettergi_log/
     └── ...               # 前端相关文件
 ```
 
+## 前端使用说明
+
+前端源码位于 `website` 目录，基于 **Next.js** 和 **Tailwind CSS** 构建，并使用 **Recharts** 渲染趋势图表。
+
+### 安装依赖
+
+```bash
+cd website
+pnpm install
+```
+
+### 开发与构建
+
+```bash
+pnpm dev   # 启动开发服务器
+pnpm build # 生产环境构建
+pnpm lint  # 运行代码检查
+```
+
+运行后端接口后，访问 `pnpm dev` 提供的地址即可预览前端页面。
+
 ## API接口
 
 ### 获取日志列表

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react"
 import "@/app/globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
+import { Toaster } from "@/components/ui/toaster"
 
 export const metadata = {
   title: "参量质变仪",
@@ -18,6 +19,7 @@ export default function RootLayout({
       <body className="bg-white text-black">
         <ThemeProvider attribute="class" enableSystem={false} disableTransitionOnChange>
           {children}
+          <Toaster />
         </ThemeProvider>
       </body>
     </html>

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -7,6 +7,19 @@ import { Search, BarChart2, CalendarIcon, Github, X, TrendingUp, Clock, Package 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { motion, AnimatePresence } from "framer-motion"
+import { useToast } from "@/hooks/use-toast"
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+} from "recharts"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
 
 interface InventoryData {
   item_count: Record<string, number>
@@ -36,13 +49,13 @@ interface StatModalData {
 }
 
 export default function InventoryPage() {
+  const { toast } = useToast()
   const [dateList, setDateList] = useState<DateItem[]>([])
   const [selectedDate, setSelectedDate] = useState<string>("") 
   const [data, setData] = useState<InventoryData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
-  const [isChangingDate, setIsChangingDate] = useState(false)
   const [animationKey, setAnimationKey] = useState(0)
   const [hoverIndex, setHoverIndex] = useState<number | null>(null)
   const [selectedItem, setSelectedItem] = useState<string | null>(null)
@@ -101,33 +114,24 @@ export default function InventoryPage() {
     })
 
     try {
-      // 调用相应的API获取趋势数据
-      const apiEndpoint = type === "totalItems" ? "/api/total-items-trend" : "/api/duration-trend"
+      const apiEndpoint =
+        type === "totalItems" ? "/api/total-items-trend" : "/api/duration-trend"
       const response = await fetch(apiEndpoint)
-
-      if (response.ok) {
-        const trendData = await response.json()
-        setStatModal((prev) => (prev ? { ...prev, data: trendData.data, loading: false } : null))
-      } else {
-        // 如果API调用失败，使用模拟数据
-        const mockTrendData: ItemTrendData = generateMockTrendData(type)
-        setStatModal((prev) => (prev ? { ...prev, data: mockTrendData, loading: false } : null))
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
       }
+      const trendData = await response.json()
+      setStatModal((prev) =>
+        prev ? { ...prev, data: trendData.data, loading: false } : null
+      )
     } catch (error) {
       console.error(`获取${titles[type]}数据失败:`, error)
-      // 使用模拟数据作为备选
-      const mockTrendData: ItemTrendData = generateMockTrendData(type)
-      setStatModal((prev) => (prev ? { ...prev, data: mockTrendData, loading: false } : null))
+      setStatModal(null)
+      toast({
+        title: `获取${titles[type]}数据失败`,
+        variant: "destructive",
+      })
     }
-  }
-
-  // 生成模拟趋势数据
-  const generateMockTrendData = (type: "totalItems" | "duration"): ItemTrendData => {
-    const dates = [
-      "20250520",
-    ]
-    const mockData: ItemTrendData = {"20250520":10}
-    return mockData
   }
 
   // 处理物品点击
@@ -136,25 +140,21 @@ export default function InventoryPage() {
     setLoadingTrend(true)
 
     try {
-      // 调用API获取物品趋势数据
-      const response = await fetch(`/api/item-trend?item=${encodeURIComponent(itemName)}`)
-      if (response.ok) {
-        const trendData = await response.json()
-        setItemTrendData(trendData.data)
-      } else {
-        // 如果API调用失败，使用模拟数据
-        const mockTrendData: ItemTrendData = {
-          "2025-05-20": 11,
-        }
-        setItemTrendData(mockTrendData)
+      const response = await fetch(
+        `/api/item-trend?item=${encodeURIComponent(itemName)}`
+      )
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
       }
+      const trendData = await response.json()
+      setItemTrendData(trendData.data)
     } catch (error) {
       console.error("获取物品趋势数据失败:", error)
-      // 使用模拟数据作为备选
-      const mockTrendData: ItemTrendData = {
-        "2025-05-20": 11,
-      }
-      setItemTrendData(mockTrendData)
+      setItemTrendData(null)
+      toast({
+        title: "获取物品趋势数据失败",
+        variant: "destructive",
+      })
     } finally {
       setLoadingTrend(false)
     }
@@ -170,25 +170,13 @@ export default function InventoryPage() {
     setStatModal(null)
   }
 
-    // 处理日期变化
+  // 处理日期变化
   const handleDateChange = (newDate: string) => {
-      if (newDate !== selectedDate) {
-        setIsChangingDate(true)
-  
-        // 短暂延迟以允许退出动画完成
-        setTimeout(() => {
-          setSelectedDate(newDate)
-          setAnimationKey((prev) => prev + 1)
-  
-          // 模拟数据加载
-          setLoading(true)
-          setTimeout(() => {
-            setLoading(false)
-            setIsChangingDate(false)
-          }, 600)
-        }, 300)
-      }
+    if (newDate !== selectedDate) {
+      setSelectedDate(newDate)
+      setAnimationKey((prev) => prev + 1)
     }
+  }
 
   // 从API获取日期列表
   useEffect(() => {
@@ -221,6 +209,7 @@ export default function InventoryPage() {
       } catch (error) {
         console.error('Error fetching date list:', error)
         setError('获取日期列表失败，请稍后再试')
+        toast({ title: '获取日期列表失败', variant: 'destructive' })
       } finally {
         setLoading(false)
       }
@@ -252,6 +241,7 @@ export default function InventoryPage() {
       } catch (error) {
         console.error('Error fetching data:', error)
         setError('获取数据失败，请稍后再试')
+        toast({ title: '获取数据失败', variant: 'destructive' })
       } finally {
         setLoading(false)
       }
@@ -578,7 +568,7 @@ const chartVariants = {
                   ></div>
                 </div>
               ) : itemTrendData ? (
-                <TrendChart data={itemTrendData} title={selectedItem} colors={colors} type="item" />
+                <TrendChart data={itemTrendData} title="数量变化趋势" colors={colors} type="item" />
               ) : (
                 <div className="text-center text-gray-500 h-64 flex items-center justify-center">暂无趋势数据</div>
               )}
@@ -1087,44 +1077,17 @@ function TrendChart({
   colors: any
   type: "totalItems" | "duration" | "item"
 }) {
-  const sortedData = Object.entries(data).sort(([a], [b]) => a.localeCompare(b))
-  const maxValue = Math.max(...Object.values(data))
-  const minValue = Math.min(...Object.values(data))
+  const chartData = Object.entries(data)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, value]) => ({ date, value }))
 
-  const chartWidth = 600
-  const chartHeight = 300
-  const padding = 60
-  const innerWidth = chartWidth - 2 * padding
-  const innerHeight = chartHeight - 2 * padding
-
-  // 格式化数值显示
-  const formatValue = (value: number) => {
-    if (type === "duration") {
-      // 将分钟数转换为时间格式
-      const hours = Math.floor(value / 60)
-      const minutes = value % 60
-      return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`
-    }
-    return value.toString()
+  const chartConfig = {
+    value: {
+      label: type === "duration" ? "分钟" : "数量",
+      color: colors.primary,
+    },
   }
 
-  // 计算点的位置
-  const points = sortedData.map(([date, value], index) => {
-    const x = padding + (index / (sortedData.length - 1)) * innerWidth
-    const y = padding + ((maxValue - value) / (maxValue - minValue || 1)) * innerHeight
-    return { x, y, date, value }
-  })
-
-  // 生成路径字符串
-  const pathData = points.reduce((path, point, index) => {
-    const command = index === 0 ? "M" : "L"
-    return `${path} ${command} ${point.x} ${point.y}`
-  }, "")
-
-  // 生成渐变区域路径
-  const areaPath = `${pathData} L ${points[points.length - 1].x} ${padding + innerHeight} L ${padding} ${padding + innerHeight} Z`
-
-  // 获取图标
   const getIcon = () => {
     switch (type) {
       case "totalItems":
@@ -1141,133 +1104,24 @@ function TrendChart({
       <div className="mb-4 flex items-center gap-2">
         {getIcon()}
         <span className="font-medium" style={{ color: colors.secondary }}>
-          {type === "totalItems" ? "总物品数量变化趋势" : type === "duration" ? "运行时间变化趋势" : "数量变化趋势"}
+          {title}
         </span>
       </div>
-
-      <div className="bg-gray-50 rounded-lg p-4">
-        <svg width="100%" height="300" viewBox={`0 0 ${chartWidth} ${chartHeight}`} className="overflow-visible">
-          {/* 网格线 */}
-          <defs>
-            <pattern id="grid" width="40" height="30" patternUnits="userSpaceOnUse">
-              <path d="M 40 0 L 0 0 0 30" fill="none" stroke="#e5e5e5" strokeWidth="1" />
-            </pattern>
-            <linearGradient id="areaGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-              <stop offset="0%" stopColor={colors.primary} stopOpacity="0.3" />
-              <stop offset="100%" stopColor={colors.primary} stopOpacity="0.05" />
-            </linearGradient>
-          </defs>
-
-          <rect x={padding} y={padding} width={innerWidth} height={innerHeight} fill="url(#grid)" />
-
-          {/* Y轴标签 */}
-          {[0, 0.25, 0.5, 0.75, 1].map((ratio) => {
-            const value = Math.round(minValue + (maxValue - minValue) * (1 - ratio))
-            const y = padding + ratio * innerHeight
-            return (
-              <g key={ratio}>
-                <line x1={padding - 5} y1={y} x2={padding} y2={y} stroke="#666" strokeWidth="1" />
-                <text x={padding - 10} y={y + 4} textAnchor="end" fontSize="12" fill="#666">
-                  {type === "duration" ? (value > 60 ? `${Math.floor(value / 60)}h` : `${value}m`) : value}
-                </text>
-              </g>
-            )
-          })}
-
-          {/* 渐变区域 */}
-          <path d={areaPath} fill="url(#areaGradient)" />
-
-          {/* 折线 */}
-          <motion.path
-            d={pathData}
-            fill="none"
-            stroke={colors.primary}
-            strokeWidth="3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            initial={{ pathLength: 0 }}
-            animate={{ pathLength: 1 }}
-            transition={{ duration: 1.5, ease: "easeInOut" }}
+      <ChartContainer config={chartConfig} className="h-64 w-full">
+        <LineChart data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" />
+          <YAxis />
+          <ChartTooltip content={<ChartTooltipContent />} />
+          <Line
+            type="monotone"
+            dataKey="value"
+            stroke="var(--color-value)"
+            strokeWidth={2}
+            dot={false}
           />
-
-          {/* 数据点 */}
-          {points.map((point, index) => (
-            <motion.g key={index}>
-              <motion.circle
-                cx={point.x}
-                cy={point.y}
-                r="4"
-                fill="white"
-                stroke={colors.primary}
-                strokeWidth="3"
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
-                transition={{ delay: index * 0.1 + 0.5, duration: 0.3 }}
-                whileHover={{ scale: 1.5 }}
-              />
-
-              {/* X轴标签 */}
-              <text
-                x={point.x}
-                y={padding + innerHeight + 20}
-                textAnchor="middle"
-                fontSize="11"
-                fill="#666"
-                transform={`rotate(-45, ${point.x}, ${padding + innerHeight + 20})`}
-              >
-                {point.date.slice(4)} {/* 只显示月-日 */}
-              </text>
-
-              {/* 悬停提示 */}
-              <motion.g opacity={0} whileHover={{ opacity: 1 }} transition={{ duration: 0.2 }}>
-                <rect x={point.x - 35} y={point.y - 35} width="70" height="25" fill="rgba(0,0,0,0.8)" rx="4" />
-                <text x={point.x} y={point.y - 18} textAnchor="middle" fontSize="12" fill="white">
-                  {formatValue(point.value)}
-                </text>
-              </motion.g>
-            </motion.g>
-          ))}
-
-          {/* 坐标轴 */}
-          <line x1={padding} y1={padding} x2={padding} y2={padding + innerHeight} stroke="#333" strokeWidth="2" />
-          <line
-            x1={padding}
-            y1={padding + innerHeight}
-            x2={padding + innerWidth}
-            y2={padding + innerHeight}
-            stroke="#333"
-            strokeWidth="2"
-          />
-        </svg>
-      </div>
-
-      {/* 统计信息 */}
-      <div className="mt-4 grid grid-cols-3 gap-4 text-center">
-        <div className="p-3 rounded-lg" style={{ backgroundColor: colors.light }}>
-          <div className="text-sm" style={{ color: colors.secondary }}>
-            最大值
-          </div>
-          <div className="text-xl font-bold" style={{ color: colors.darkText }}>
-            {formatValue(maxValue)}
-          </div>
-        </div>
-        <div className="p-3 rounded-lg" style={{ backgroundColor: colors.light }}>
-          <div className="text-sm" style={{ color: colors.secondary }}>
-            最小值
-          </div>
-          <div className="text-xl font-bold" style={{ color: colors.darkText }}>
-            {formatValue(minValue)}
-          </div>
-        </div>
-        <div className="p-3 rounded-lg" style={{ backgroundColor: colors.light }}>
-          <div className="text-sm" style={{ color: colors.secondary }}>
-            平均值
-          </div>
-          <div className="text-xl font-bold" style={{ color: colors.darkText }}>
-            {formatValue(Math.round(Object.values(data).reduce((a, b) => a + b, 0) / Object.values(data).length))}
-          </div>
-        </div>
-      </div>
+        </LineChart>
+      </ChartContainer>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove mock data and load real API results with toast-based error handling
- present trend metrics using Recharts-based chart component
- document frontend usage, dependencies, and add toaster support

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b962804fe8833091452083ad8cace5