### PR TITLE
feat: add stats route with chart and tests

### DIFF
--- a/website/__tests__/stats.test.tsx
+++ b/website/__tests__/stats.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import StatsPage from '@/app/stats/page'
+import { vi } from 'vitest'
+
+describe('StatsPage', () => {
+  const mockData = {
+    data: [
+      {
+        group: 'A',
+        lastDuration: 5,
+        avgDuration: 3,
+        success: 2,
+        failure: 1,
+        outputs: { x: 1 },
+        date: '2024-01-01',
+      },
+    ],
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+      blob: () => Promise.resolve(new Blob()),
+    }) as any
+  })
+
+  it('fetches data and switches time window', async () => {
+    render(<StatsPage />)
+    expect(fetch).toHaveBeenCalledWith('/api/stats?window=1')
+    await waitFor(() => screen.getByText('A'))
+    await userEvent.selectOptions(screen.getByLabelText('Time Window'), '7')
+    await waitFor(() => expect(fetch).toHaveBeenLastCalledWith('/api/stats?window=7'))
+  })
+
+  it('calls export endpoints', async () => {
+    render(<StatsPage />)
+    await waitFor(() => screen.getByText('A'))
+    await userEvent.click(screen.getByText('Export CSV'))
+    expect(fetch).toHaveBeenCalledWith('/api/stats/export?window=1&format=csv')
+    await userEvent.click(screen.getByText('Export JSON'))
+    expect(fetch).toHaveBeenCalledWith('/api/stats/export?window=1&format=json')
+  })
+
+  it('toggles chart type and dimension', async () => {
+    render(<StatsPage />)
+    await waitFor(() => screen.getByText('A'))
+    await userEvent.click(screen.getByText('Line'))
+    expect(screen.getByText('Bar')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('By Date'))
+    expect(screen.getByText('By Group')).toBeInTheDocument()
+  })
+})

--- a/website/app/stats/page.tsx
+++ b/website/app/stats/page.tsx
@@ -1,0 +1,171 @@
+"use client"
+
+import React from "react"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+} from "@/components/ui/chart"
+import { BarChart, Bar, LineChart, Line, XAxis, YAxis } from "recharts"
+
+interface StatItem {
+  group: string
+  lastDuration: number
+  avgDuration: number
+  success: number
+  failure: number
+  outputs: Record<string, number>
+  date: string
+}
+
+interface StatsResponse {
+  data: StatItem[]
+}
+
+export default function StatsPage() {
+  const [timeWindow, setTimeWindow] = React.useState(1)
+  const [stats, setStats] = React.useState<StatItem[]>([])
+  const [chartType, setChartType] = React.useState<"bar" | "line">("bar")
+  const [dimension, setDimension] = React.useState<"group" | "date">(
+    "group"
+  )
+
+  const fetchStats = React.useCallback(async () => {
+    const res = await fetch(`/api/stats?window=${timeWindow}`)
+    if (res.ok) {
+      const json: StatsResponse = await res.json()
+      setStats(json.data)
+    }
+  }, [timeWindow])
+
+  React.useEffect(() => {
+    fetchStats()
+  }, [fetchStats])
+
+  const handleExport = async (format: "csv" | "json") => {
+    const res = await fetch(
+      `/api/stats/export?window=${timeWindow}&format=${format}`
+    )
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = `stats.${format}`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const chartData = React.useMemo(() => {
+    const map: Record<string, { total: number; count: number }> = {}
+    if (dimension === "group") {
+      stats.forEach((s) => {
+        const entry = map[s.group] || { total: 0, count: 0 }
+        entry.total += s.avgDuration
+        entry.count += 1
+        map[s.group] = entry
+      })
+    } else {
+      stats.forEach((s) => {
+        const entry = map[s.date] || { total: 0, count: 0 }
+        entry.total += s.avgDuration
+        entry.count += 1
+        map[s.date] = entry
+      })
+    }
+    return Object.entries(map).map(([label, { total, count }]) => ({
+      label,
+      value: total / count,
+    }))
+  }, [stats, dimension])
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <label htmlFor="window">Time Window</label>
+        <select
+          id="window"
+          value={timeWindow}
+          onChange={(e) => setTimeWindow(Number(e.target.value))}
+          className="border p-1"
+        >
+          <option value={1}>1</option>
+          <option value={7}>7</option>
+          <option value={30}>30</option>
+        </select>
+        <Button onClick={() => setChartType(chartType === "bar" ? "line" : "bar")}>
+          {chartType === "bar" ? "Line" : "Bar"}
+        </Button>
+        <Button
+          onClick={() =>
+            setDimension(dimension === "group" ? "date" : "group")
+          }
+        >
+          {dimension === "group" ? "By Date" : "By Group"}
+        </Button>
+        <Button onClick={() => handleExport("csv")}>Export CSV</Button>
+        <Button onClick={() => handleExport("json")}>Export JSON</Button>
+      </div>
+      <ChartContainer
+        config={{ value: { label: "Avg Duration", color: "hsl(var(--chart-1))" } }}
+      >
+        {chartType === "bar" ? (
+          <BarChart data={chartData}>
+            <XAxis dataKey="label" />
+            <YAxis />
+            <ChartTooltip content={<ChartTooltipContent />} />
+            <Bar dataKey="value" fill="var(--color-value)" />
+            <ChartLegend content={<ChartLegendContent />} />
+          </BarChart>
+        ) : (
+          <LineChart data={chartData}>
+            <XAxis dataKey="label" />
+            <YAxis />
+            <ChartTooltip content={<ChartTooltipContent />} />
+            <Line type="monotone" dataKey="value" stroke="var(--color-value)" />
+            <ChartLegend content={<ChartLegendContent />} />
+          </LineChart>
+        )}
+      </ChartContainer>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>配置組</TableHead>
+            <TableHead>最近一次耗時</TableHead>
+            <TableHead>平均耗時</TableHead>
+            <TableHead>成功/失敗次數</TableHead>
+            <TableHead>產物分類與數量</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {stats.map((s) => (
+            <TableRow key={s.group + s.date}>
+              <TableCell>{s.group}</TableCell>
+              <TableCell>{s.lastDuration}</TableCell>
+              <TableCell>{s.avgDuration}</TableCell>
+              <TableCell>
+                {s.success}/{s.failure}
+              </TableCell>
+              <TableCell>
+                {Object.entries(s.outputs)
+                  .map(([k, v]) => `${k}:${v}`)
+                  .join(", ")}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -66,6 +67,12 @@
     "@types/react-dom": "^19",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^2.1.4",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.5.2",
+    "jsdom": "^24.0.0",
+    "@vitejs/plugin-react": "^4.3.1"
   }
 }

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'node:path'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+  },
+})

--- a/website/vitest.setup.ts
+++ b/website/vitest.setup.ts
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+// Mock createObjectURL for tests involving file downloads
+// @ts-ignore
+if (!global.URL.createObjectURL) {
+  // @ts-ignore
+  global.URL.createObjectURL = vi.fn()
+}
+// @ts-ignore
+if (!global.URL.revokeObjectURL) {
+  // @ts-ignore
+  global.URL.revokeObjectURL = vi.fn()
+}


### PR DESCRIPTION
## Summary
- add stats page with table, chart, time window switch and export
- configure vitest and add tests for stats interactions

## Testing
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b971cb32108330ac59b6c9fb8884f9