### PR TITLE
Fix first_run initialization

### DIFF
--- a/lite_runner.py
+++ b/lite_runner.py
@@ -399,7 +399,7 @@ def main() -> int:
         setup_signal_handlers()
 
         first_run = is_first_run()
-        first_run = True;
+        # first_run = True  # 保留注释以方便调试
 
         if first_run:
             logger.info("首次运行，将进行完整初始化...")


### PR DESCRIPTION
## Summary
- remove debug override of `first_run` so initialization runs only when needed

## Testing
- `python -m py_compile lite_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68b977599a88833089b513ab3b8c1f27