### PR TITLE
Define module-level logger in mini app

### DIFF
--- a/mini/app.py
+++ b/mini/app.py
@@ -1,10 +1,14 @@
 import os
 import re
+import logging
 from datetime import datetime
 from collections import defaultdict
+
 from flask import Flask, jsonify, request, send_from_directory
 from dotenv import load_dotenv
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 # 加载环境变量
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- add logging import and module-level logger setup
- keep critical log call using the new logger

## Testing
- `python -m py_compile mini/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9775674d08330a4587a95f40ee9cb