### PR TITLE
feat: lazy load logs

### DIFF
--- a/mini/app.py
+++ b/mini/app.py
@@ -223,6 +223,13 @@ def get_log_list():
     return filtered_logs
 
 
+def load_logs_if_needed():
+    """Load and cache log data if it has not been loaded yet."""
+    global log_list
+    if log_list is None or item_dataframe.empty or duration_dataframe.empty:
+        log_list = get_log_list()
+
+
 # 路由定义
 @app.route('/')
 def serve_index():
@@ -248,11 +255,8 @@ def get_log_list_api():
     Returns:
         JSON: 包含日志文件列表的JSON响应.例如：{'list': ['20250501']}
     """
-    global log_list
-    if not log_list:
-        log_list = get_log_list()
-    log_list.reverse()  # 最新的日志排在前面
-    return jsonify({'list': log_list})
+    load_logs_if_needed()
+    return jsonify({'list': list(reversed(log_list))})
 
 
 @app.route('/api/analyse', methods=['GET'])
@@ -267,6 +271,7 @@ def analyse_log():
         'item_count': {item_name:int}
     }
     """
+    load_logs_if_needed()
     date = request.args.get('date', 'all')
 
     if date == 'all':
@@ -285,6 +290,7 @@ def item_trend():
         'data': {‘date':int}
     }
     """
+    load_logs_if_needed()
     item_name = request.args.get('item', '')
     if item_name:
         return analyse_item_history(item_name)
@@ -301,6 +307,7 @@ def duration_trend():
         'data': {‘date':int}
     }
     """
+    load_logs_if_needed()
     return analyse_duration_history()
 
 
@@ -314,6 +321,7 @@ def item_history():
         'data': {‘date':int}
     }
     """
+    load_logs_if_needed()
     return analyse_all_items()
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+

--- a/release/app.py
+++ b/release/app.py
@@ -333,6 +333,13 @@ def get_log_list():
     return filtered_logs
 
 
+def load_logs_if_needed():
+    """Load and cache log data if it has not been loaded yet."""
+    global log_list
+    if log_list is None or item_dataframe.empty or duration_dataframe.empty:
+        log_list = get_log_list()
+
+
 # 路由定义
 @app.route('/')
 def serve_index():
@@ -358,11 +365,8 @@ def get_log_list_api():
     Returns:
         JSON: 包含日志文件列表的JSON响应.例如：{'list': ['20250501']}
     """
-    global log_list
-    if not log_list:
-        log_list = get_log_list()
-    log_list.reverse()  # 最新的日志排在前面
-    return jsonify({'list': log_list})
+    load_logs_if_needed()
+    return jsonify({'list': list(reversed(log_list))})
 
 
 @app.route('/api/analyse', methods=['GET'])
@@ -377,6 +381,7 @@ def analyse_log():
         'item_count': {item_name:int}
     }
     """
+    load_logs_if_needed()
     date = request.args.get('date', 'all')
 
     if date == 'all':
@@ -395,6 +400,7 @@ def item_trend():
         'data': {‘date':int}
     }
     """
+    load_logs_if_needed()
     item_name = request.args.get('item', '')
     if item_name:
         return analyse_item_history(item_name)
@@ -411,6 +417,7 @@ def duration_trend():
         'data': {‘date':int}
     }
     """
+    load_logs_if_needed()
     return analyse_duration_history()
 
 
@@ -424,6 +431,7 @@ def item_history():
         'data': {‘date':int}
     }
     """
+    load_logs_if_needed()
     return analyse_all_items()
 
 

--- a/tests/test_lazy_initialization.py
+++ b/tests/test_lazy_initialization.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def create_sample_log(path):
+    content = (
+        "[12:00:00.000] [INFO] Test\n"
+        "初始化\n"
+        "[12:01:00.000] [INFO] Test\n"
+        "交互或拾取：\"苹果\"\n"
+    )
+    path.write_text(content, encoding="utf-8")
+
+
+def test_lazy_initialization(tmp_path, monkeypatch):
+    log_dir = tmp_path / "log"
+    log_dir.mkdir()
+    create_sample_log(log_dir / "better-genshin-impact20240101.log")
+
+    monkeypatch.setenv("BETTERGI_PATH", str(tmp_path))
+
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    app_module = importlib.import_module("mini.app")
+    client = app_module.app.test_client()
+
+    assert app_module.log_list is None
+    assert app_module.item_dataframe.empty
+    assert app_module.duration_dataframe.empty
+
+    analyse_resp = client.get("/api/analyse")
+    assert analyse_resp.status_code == 200
+    assert analyse_resp.get_json()["item_count"] == {"苹果": 1}
+
+    assert app_module.log_list is not None
+    assert not app_module.item_dataframe.empty
+    assert not app_module.duration_dataframe.empty
+
+    list_resp = client.get("/api/LogList")
+    assert list_resp.status_code == 200
+    assert "20240101" in list_resp.get_json()["list"]
+


### PR DESCRIPTION
## Summary
- add load_logs_if_needed to populate cached log data on demand
- use load_logs_if_needed across all log-dependent endpoints
- test that /api/analyse triggers lazy initialization when called before /api/LogList

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b95db37a408330ab9046c9754d1e07