### PR TITLE
Handle malformed BGI log lines

### DIFF
--- a/mini/app.py
+++ b/mini/app.py
@@ -97,7 +97,12 @@ def parse_log(log_content, date_str):
 
         # 提取拾取内容
         if '交互或拾取' in details:
-            item = details.split('：')[1].strip('"')
+            # 使用 partition 确保分隔符存在
+            _, sep, item_part = details.partition('：')
+            if not sep:
+                app.logger.warning(f"缺少分隔符的日志行：{details}")
+                continue
+            item = item_part.strip('"')
             # interaction_items.append(item)
             item_count[item] = item_count.get(item, 0) + 1
 

--- a/server/app.py
+++ b/server/app.py
@@ -96,7 +96,12 @@ def parse_log(log_content):
         
         # 提取拾取内容
         if '交互或拾取' in details:
-            item = details.split('：')[1].strip('"')
+            # 使用 partition 确保分隔符存在
+            _, sep, item_part = details.partition('：')
+            if not sep:
+                app.logger.warning(f"缺少分隔符的日志行：{details}")
+                continue
+            item = item_part.strip('"')
             interaction_items.append(item)
             item_count[item] = item_count.get(item, 0) + 1
         

--- a/tests/test_parse_log.py
+++ b/tests/test_parse_log.py
@@ -1,0 +1,40 @@
+import os
+import logging
+import importlib.util
+from pathlib import Path
+
+# Ensure required environment variable exists before importing modules
+os.environ.setdefault('BETTERGI_PATH', '/tmp')
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+server_module = load_module("server.app", REPO_ROOT / "server" / "app.py")
+mini_module = load_module("mini.app", REPO_ROOT / "mini" / "app.py")
+
+server_parse_log = server_module.parse_log
+server_app = server_module.app
+mini_parse_log = mini_module.parse_log
+mini_app = mini_module.app
+
+
+def test_server_parse_log_missing_delimiter(caplog):
+    log_content = "[00:00:00.000] [INFO] Test\n交互或拾取 \"Item\"\n"
+    with caplog.at_level(logging.WARNING, logger=server_app.logger.name):
+        result = server_parse_log(log_content)
+    assert result['item_count'] == {}
+    assert '分隔符' in caplog.text
+
+
+def test_mini_parse_log_missing_delimiter(caplog):
+    log_content = "[00:00:00.000] [INFO] Test\n交互或拾取 \"Item\"\n"
+    with caplog.at_level(logging.WARNING, logger=mini_app.logger.name):
+        result = mini_parse_log(log_content, '20240101')
+    assert result['item_count'] == {}
+    assert result['cache_dict']['物品名称'] == []
+    assert '分隔符' in caplog.text


### PR DESCRIPTION
## Summary
- Guard against missing delimiters when parsing `交互或拾取` logs in both server and mini apps
- Skip malformed entries and record a warning instead of crashing
- Add unit tests for parsing logs lacking the separator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b97c23085c8330bbd6fd2e52f97317