### PR TITLE
Fix import ordering in lite_runner

### DIFF
--- a/lite_runner.py
+++ b/lite_runner.py
@@ -16,16 +16,16 @@ BetterGI日志分析工具初始化脚本
 """
 
 import os
-import sys
-import subprocess
-import platform
-import logging
-import signal
-import time
 import json
-from typing import Optional, Tuple, List, Dict, Any, Union
+import logging
+import platform
 import shutil
-import os
+import signal
+import subprocess
+import sys
+import time
+
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 # 配置日志
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- remove duplicate `os` import
- order imports in `lite_runner.py` per PEP 8

## Testing
- `python -m py_compile lite_runner.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b97c222fa08330918b59104c85574a