### PR TITLE
Add logging to log parsing modules

### DIFF
--- a/mini/app.py
+++ b/mini/app.py
@@ -1,12 +1,20 @@
 import os
 import re
+import logging
 from datetime import datetime
 from collections import defaultdict
 from flask import Flask, jsonify, request, send_from_directory
 from dotenv import load_dotenv
 import pandas as pd
+
 # 加载环境变量
 load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s]: %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 # 获取日志目录路径
 BGI_LOG_DIR = os.path.join(os.getenv('BETTERGI_PATH'), 'log')

--- a/server/analyse.py
+++ b/server/analyse.py
@@ -1,7 +1,15 @@
+import logging
 import re
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s]: %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 
 def parse_log(log_content):
+    logger.debug("Parsing log content")
     log_pattern = r'\[([^]]+)\] \[([^]]+)\] ([^\n]+)\n?([^\n[]*)'
     matches = re.findall(log_pattern, log_content)
 
@@ -38,9 +46,9 @@ def read_log_file(file_path):
             log_content = file.read()
         return parse_log(log_content)
     except FileNotFoundError:
-        print("错误: 文件未找到!")
+        logger.error("错误: 文件未找到!")
     except Exception as e:
-        print(f"错误: 发生了一个未知错误: {e}")
+        logger.exception("错误: 发生了一个未知错误: %s", e)
     return None
 
 

--- a/server/app.py
+++ b/server/app.py
@@ -1,5 +1,6 @@
 import os
 import re
+import logging
 from datetime import datetime
 from collections import defaultdict
 from flask import Flask, jsonify, request, send_from_directory
@@ -7,6 +8,12 @@ from dotenv import load_dotenv
 
 # 加载环境变量
 load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s]: %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 # 获取日志目录路径
 BGI_LOG_DIR = os.path.join(os.getenv('BETTERGI_PATH'), 'log')
@@ -77,6 +84,7 @@ def parse_log(log_content):
     """
     log_pattern = r'\[([^]]+)\] \[([^]]+)\] ([^\n]+)\n?([^\n[]*)'  
     matches = re.findall(log_pattern, log_content)
+    logger.debug("Parsed %d log entries", len(matches))
     
     type_count = {}
     interaction_items = []


### PR DESCRIPTION
## Summary
- configure logging and create module-level loggers in Flask and analysis modules
- replace print-based error handling with logger calls
- log parsed entry counts during log parsing for easier debugging

## Testing
- `python -m py_compile mini/app.py server/analyse.py server/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b97c1e7cd88330913df31807c02f7a