### PR TITLE
Refine artifact categorization rules and add regression test

### DIFF
--- a/website/utils/categoryRules.ts
+++ b/website/utils/categoryRules.ts
@@ -1,0 +1,41 @@
+export type Category = "圣遗物" | "矿物" | "食材" | "其他";
+
+interface Rule {
+  category: Category;
+  match: (name: string) => boolean;
+}
+
+const artifactSetNames = ["冒险家", "游医", "幸运儿"];
+
+const artifactPieceRegex = /的(方巾|枭羽|怀钟|药壶|银莲|怀表|尾羽|头带|金杯|之花|之杯|沙漏|绿花|银冠|鹰羽)$/;
+
+export const categoryRules: Rule[] = [
+  {
+    category: "圣遗物",
+    match: (name: string) =>
+      artifactSetNames.some(set => name.includes(set)) ||
+      artifactPieceRegex.test(name),
+  },
+  {
+    category: "矿物",
+    match: (name: string) =>
+      ["铁块", "白铁块", "水晶块", "魔晶块", "星银矿石", "紫晶块", "萃凝晶"].includes(name),
+  },
+  {
+    category: "食材",
+    match: (name: string) =>
+      [
+        "苹果", "蘑菇", "甜甜花", "胡萝卜", "白萝卜", "金鱼草", "薄荷",
+        "松果", "树莓", "松茸", "鸟蛋", "海草", "堇瓜", "墩墩桃",
+        "须弥蔷薇", "枣椰", "茉洁草", "沉玉仙茗", "颗粒果", "澄晶实",
+        "红果果菇", "小灯草", "嘟嘟莲", "莲蓬", "绝云椒椒", "清心",
+        "马尾", "琉璃袋", "竹笋", "绯樱绣球", "树王圣体菇", "帕蒂沙兰",
+        "青蜜莓",
+      ].includes(name),
+  },
+];
+
+export function getCategoryFromRules(name: string): Category {
+  const rule = categoryRules.find(r => r.match(name));
+  return rule ? rule.category : "其他";
+}

--- a/website/utils/getCategory.test.ts
+++ b/website/utils/getCategory.test.ts
@@ -1,0 +1,7 @@
+import assert from 'assert'
+import { getCategory } from './getCategory'
+
+assert.strictEqual(getCategory('冒险家的花'), '圣遗物')
+assert.strictEqual(getCategory('作家笔记'), '其他')
+
+console.log('All tests passed')

--- a/website/utils/getCategory.ts
+++ b/website/utils/getCategory.ts
@@ -1,0 +1,5 @@
+import { getCategoryFromRules } from './categoryRules'
+
+export function getCategory(name: string) {
+  return getCategoryFromRules(name)
+}


### PR DESCRIPTION
## Summary
- simplify artifact rule to explicit set names and regex only
- add regression test for names containing `家` that are not artifacts

## Testing
- `npx tsc website/utils/getCategory.test.ts website/utils/getCategory.ts website/utils/categoryRules.ts --module commonjs --target ES2019 --esModuleInterop --typeRoots website/node_modules/@types --outDir website/utils/dist`
- `node website/utils/dist/getCategory.test.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b989955698833097c704c50c35bd51