### PR TITLE
Add unit tests for log parsing utilities

### DIFF
--- a/tests/test_mini_app.py
+++ b/tests/test_mini_app.py
@@ -1,0 +1,31 @@
+import os
+import importlib.util
+
+os.environ.setdefault('BETTERGI_PATH', '/tmp/bgi')
+
+spec = importlib.util.spec_from_file_location("mini_app", os.path.join("mini", "app.py"))
+mini_app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mini_app)
+
+format_timedelta = mini_app.format_timedelta
+parse_log = mini_app.parse_log
+
+def test_format_timedelta():
+    assert format_timedelta(None) == "0分钟"
+    assert format_timedelta(65) == "1分钟"
+    assert format_timedelta(3600 + 180) == "1小时3分钟"
+
+def test_parse_log_filters_and_counts_items():
+    log_content = (
+        "[00:00:00.000] [INFO] ClassA\n"
+        "start\n"
+        "[00:01:00.000] [INFO] ClassB\n"
+        "交互或拾取：\"苹果\"\n"
+        "[00:02:00.000] [INFO] ClassC\n"
+        "交互或拾取：\"调查\"\n"
+        "[00:02:30.000] [INFO] ClassD\n"
+        "交互或拾取：\"苹果\"\n"
+    )
+    result = parse_log(log_content, "20250101")
+    assert result["item_count"] == {"苹果": 2}
+    assert result["duration"] == 150

--- a/tests/test_server_analyse.py
+++ b/tests/test_server_analyse.py
@@ -1,0 +1,32 @@
+import importlib.util
+import os
+
+spec = importlib.util.spec_from_file_location("server_analyse", os.path.join("server", "analyse.py"))
+server_analyse = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(server_analyse)
+
+parse_log = server_analyse.parse_log
+read_log_file = server_analyse.read_log_file
+
+
+def sample_log():
+    return (
+        "[00:00:00.000] [INFO] ClassA\n"
+        "交互或拾取：\"苹果\"\n"
+        "[00:01:00.000] [INFO] ClassB\n"
+        "交互或拾取：\"梨子\"\n"
+    )
+
+
+def test_parse_log_counts_types_and_items():
+    result = parse_log(sample_log())
+    assert result["type_count"] == {"ClassA": 1, "ClassB": 1}
+    assert result["interaction_items"] == ["苹果", "梨子"]
+    assert result["interaction_count"] == 2
+
+
+def test_read_log_file(tmp_path):
+    file_path = tmp_path / "log.log"
+    file_path.write_text(sample_log(), encoding="utf-8")
+    result = read_log_file(str(file_path))
+    assert result["interaction_items"] == ["苹果", "梨子"]


### PR DESCRIPTION
## Summary
- add tests for mini app parsing utilities like `format_timedelta` and `parse_log`
- cover server-side log parsing and file reading helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b98c25dfe08330b72b5f76d4ca5076