### PR TITLE
Improve log parsing performance and deduplication in LogDataManager

### DIFF
--- a/release/app/infrastructure/manager.py
+++ b/release/app/infrastructure/manager.py
@@ -17,8 +17,8 @@ logger = logging.getLogger('BetterGI初始化')
 FORBIDDEN_ITEMS = ['调查', '直接拾取']
 
 # 预编译正则表达式
-FIRST_LINE_PATTERN = re.compile(r'^\[([^]]+)\] \[([^]]+)\] ([^\n]+)\n?([^\n[]*)\n')  # 匹配日志第一行
-LOG_PATTERN = re.compile(r'\n\[([^]]+)\] \[([^]]+)\] ([^\n]+)\n?([^\n[]*)\n')  # 匹配日志行
+# 使用单个模式同时匹配首行和普通行，避免对超大日志进行多次扫描与中间列表构建
+LOG_ENTRY_PATTERN = re.compile(r'(?:^|\n)\[([^]]+)\] \[([^]]+)\] ([^\n]+)\n?([^\n[]*)\n')
 TASK_BEGIN_PATTERN = re.compile(r'^配置组 "([^"]*)" 加载完成，共(\d+)个脚本，开始执行$')  # 匹配配置组开始
 
 
@@ -36,7 +36,7 @@ class LogDataManager:
             log_dir: 日志目录路径
         """
         self.log_dir = log_dir
-        self.item_cached_list = []  # 用于替代原有的筛选功能，避免物品的重复记录
+        self.item_cached_set = set()  # 用于替代原有的筛选功能，避免物品的重复记录
         self.item_datadict = {
             '物品名称': [], '时间': [], '日期': [], '归属配置组': []
         }
@@ -64,11 +64,6 @@ class LogDataManager:
         Returns:
             LogAnalysisResult: 包含解析结果的分析结果对象
         """
-        matches = LOG_PATTERN.findall(log_content)
-        first_line_match = FIRST_LINE_PATTERN.match(log_content)
-        if first_line_match:
-            matches = [first_line_match.groups()] + matches
-
         item_count = {}
         items = []
 
@@ -78,11 +73,11 @@ class LogDataManager:
         last_time = None
         current_task = None  # 当前运行的配置组
         
-        for match in matches:
-            timestamp = match[0]  # 时间戳
+        for match in LOG_ENTRY_PATTERN.finditer(log_content):
+            timestamp = match.group(1)  # 时间戳
             # level = match[1]  # 日志级别
             # log_type = match[2]  # 类名
-            details = match[3].strip()  # 日志内容文本
+            details = match.group(4).strip()  # 日志内容文本
 
             # 过滤禁用的关键词
             if any(keyword in details for keyword in FORBIDDEN_ITEMS):
@@ -101,17 +96,20 @@ class LogDataManager:
                 current_time = parse_timestamp_to_seconds(timestamp)
             except Exception as e:
                 logger.error(f"解析时间戳{timestamp}时候发生错误:{e}")
-                logger.error(f'涉及的完整匹配字符串：{match}')
+                logger.error(f'涉及的完整匹配字符串：{match.group(0)}')
                 continue
                 
             # 提取拾取内容
             if '交互或拾取' in details:
-                item_name = details.split('：')[1].strip('"')
+                _, sep, item_part = details.partition('：')
+                if not sep:
+                    continue
+                item_name = item_part.strip('"')
                 item_count[item_name] = item_count.get(item_name, 0) + 1
 
                 # 检查是否存在匹配的行
                 cache_key = f'{item_name}{timestamp}{date_str}{current_task}'
-                if cache_key not in self.item_cached_list:
+                if cache_key not in self.item_cached_set:
                     item_info = ItemInfo(
                         name=item_name,
                         timestamp=timestamp,
@@ -119,7 +117,7 @@ class LogDataManager:
                         config_group=str(current_task) if current_task else None
                     )
                     items.append(item_info)
-                    self.item_cached_list.append(cache_key)
+                    self.item_cached_set.add(cache_key)
 
             # 处理时间段
             if last_time is None:
@@ -229,7 +227,7 @@ class LogDataManager:
             tuple: (duration, items) 今天的持续时间和物品列表，如果没有数据则返回(0, [])
         """
         # 清空缓存，因为需要重新读取今天的数据
-        self.item_cached_list = []
+        self.item_cached_set.clear()
         
         today_file_path = os.path.join(self.log_dir, f"better-genshin-impact{self.today_str}.log")
         
@@ -291,12 +289,17 @@ class LogDataManager:
             # 将今天的数据添加到字典中
             date_duration_dict[self.today_str] = today_duration
             
-            # 添加今天的物品数据（插入到最前面）
-            for item in today_items:
-                unified_item_data['物品名称'].insert(0, item.name)
-                unified_item_data['时间'].insert(0, item.timestamp)
-                unified_item_data['日期'].insert(0, item.date)
-                unified_item_data['归属配置组'].insert(0, item.config_group or '')
+            # 添加今天的物品数据（拼接到最前面，避免多次 insert(0) 导致 O(n^2)）
+            reversed_today_items = list(reversed(today_items))
+            today_names = [item.name for item in reversed_today_items]
+            today_times = [item.timestamp for item in reversed_today_items]
+            today_dates = [item.date for item in reversed_today_items]
+            today_groups = [(item.config_group or '') for item in reversed_today_items]
+
+            unified_item_data['物品名称'] = today_names + unified_item_data['物品名称']
+            unified_item_data['时间'] = today_times + unified_item_data['时间']
+            unified_item_data['日期'] = today_dates + unified_item_data['日期']
+            unified_item_data['归属配置组'] = today_groups + unified_item_data['归属配置组']
 
         # 按日期降序排列（最新的日期在前面）
         sorted_dates = sorted(date_duration_dict.keys(), reverse=True)
@@ -345,4 +348,3 @@ class LogDataManager:
         # 无视之前数据，强制刷新今天数据
         self.get_log_list()
         return self.item_datadict
-


### PR DESCRIPTION
### Motivation

- Reduce memory usage and CPU overhead when parsing very large log files by avoiding multiple passes and large intermediate lists.
- Prevent duplicate item records and make item extraction more robust against malformed lines.
- Avoid O(n^2) behavior when prepending today's items into the unified item list.

### Description

- Replaced separate `FIRST_LINE_PATTERN` and `LOG_PATTERN` with a single `LOG_ENTRY_PATTERN` and switched to `finditer` to parse entries in one pass. 
- Replaced `item_cached_list` with a `set` (`item_cached_set`) and use `.add()`/`.clear()` to deduplicate cache lookups efficiently. 
- Extract item name using `str.partition('：')` to safely handle malformed lines and log the full match via `match.group(0)` on timestamp parse errors. 
- Compute activity durations by iterating matches and building `time_segments`, and compute total `duration` as the sum of segment lengths. 
- Replace repeated `insert(0, ...)` calls by reversing today's items, building four lists (`today_names`, `today_times`, `today_dates`, `today_groups`) and concatenating them with the existing unified lists to avoid quadratic behavior. 

### Testing

- Ran the project unit test suite with `pytest -q`, and all tests passed. 
- Ran code style checks with `flake8`, and no new linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfd9a63d08330a202779d1186d6de)