### PR TITLE
補 log parser 舊格式相容並統一 /api/stream 使用 stream_manager

### DIFF
--- a/release/app/api/views.py
+++ b/release/app/api/views.py
@@ -55,6 +55,22 @@ class StreamControllerManager:
 stream_manager = StreamControllerManager()
 
 
+def _resolve_stream_target_app(explicit_target_app: str = None):
+    """
+    解析并返回可用的目标程序：
+    1. 显式指定时直接使用；
+    2. 未指定且仅有一个已创建控制器时自动使用；
+    3. 其他情况返回None。
+    """
+    if explicit_target_app:
+        return explicit_target_app
+
+    if len(stream_manager._controllers) == 1:
+        return next(iter(stream_manager._controllers.keys()))
+
+    return None
+
+
 def init_controllers(log_dir: str):
     """
     初始化控制器
@@ -212,8 +228,6 @@ def video_stream():
     Returns:
         Response: MJPEG视频流响应或JSON错误响应
     """
-    global stream_controller
-    
     # 获取查询参数中的app参数
     target_app = request.args.get('app', '').strip()
     
@@ -235,15 +249,7 @@ def video_stream():
         }), 400
     
     try:
-        # 检查是否需要重新初始化stream_controller
-        if not stream_controller or stream_controller.target_app != target_app:
-            # 如果当前有推流在进行，先停止
-            if stream_controller and stream_controller.is_streaming:
-                stream_controller.stop_stream()
-            
-            # 重新初始化推流控制器
-            stream_controller = StreamController(target_app)
-        
+        stream_controller = stream_manager.get_controller(target_app)
         return stream_controller.start_stream()
         
     except Exception as e:
@@ -260,10 +266,15 @@ def get_stream_info():
     Returns:
         Response: 包含推流状态信息的JSON响应
     """
-    if not stream_controller:
-        return jsonify({'error': '推流控制器未初始化'}), 500
+    target_app = _resolve_stream_target_app(request.args.get('app', '').strip())
+    if not target_app:
+        return jsonify({
+            'error': '推流控制器未初始化',
+            'message': '请先调用 /api/stream?app=xxx 初始化，或在查询参数中提供 app'
+        }), 400
     
     try:
+        stream_controller = stream_manager.get_controller(target_app)
         result = stream_controller.get_stream_info()
         return jsonify(result)
     except Exception as e:
@@ -280,14 +291,19 @@ def stop_stream():
     Returns:
         Response: 操作结果的JSON响应
     """
-    if not stream_controller:
-        return jsonify({'error': '推流控制器未初始化'}), 500
+    body = request.get_json(silent=True) or {}
+    target_app = _resolve_stream_target_app((body.get('app') or '').strip())
+    if not target_app:
+        return jsonify({
+            'error': '推流控制器未初始化',
+            'message': '请先调用 /api/stream?app=xxx 初始化，或在请求体中提供 app'
+        }), 400
     
     try:
-        stream_controller.stop_stream()
+        stream_manager.stop_controller(target_app)
         return jsonify({
             'success': True,
-            'message': '推流已停止'
+            'message': f'{target_app} 推流已停止'
         })
     except Exception as e:
         return jsonify({

--- a/release/app/api/views.py
+++ b/release/app/api/views.py
@@ -15,7 +15,6 @@ api_bp = Blueprint('api', __name__)
 # 全局控制器实例（将在应用启动时初始化）
 log_controller = None
 webhook_controller = None
-stream_controller = None
 
 
 class StreamControllerManager:
@@ -51,6 +50,15 @@ class StreamControllerManager:
         filtered.append('桌面.exe')
         return filtered
 
+    def get_single_target_app(self):
+        """
+        当且仅当当前只存在一个控制器时，返回对应 target_app。
+        否则返回 None。
+        """
+        if len(self._controllers) != 1:
+            return None
+        return next(iter(self._controllers.keys()))
+
 
 stream_manager = StreamControllerManager()
 
@@ -65,8 +73,9 @@ def _resolve_stream_target_app(explicit_target_app: str = None):
     if explicit_target_app:
         return explicit_target_app
 
-    if len(stream_manager._controllers) == 1:
-        return next(iter(stream_manager._controllers.keys()))
+    single_target = stream_manager.get_single_target_app()
+    if single_target:
+        return single_target
 
     return None
 
@@ -78,10 +87,9 @@ def init_controllers(log_dir: str):
     Args:
         log_dir: 日志目录路径
     """
-    global log_controller, webhook_controller, stream_controller
+    global log_controller, webhook_controller
     log_controller = LogController(log_dir)
     webhook_controller = WebhookController(log_dir)
-    # stream_controller将在首次请求时动态创建
 
 
 

--- a/release/app/infrastructure/manager.py
+++ b/release/app/infrastructure/manager.py
@@ -19,6 +19,7 @@ FORBIDDEN_ITEMS = ['调查', '直接拾取']
 # 预编译正则表达式
 FIRST_LINE_PATTERN = re.compile(r'^\[([^]]+)\] \[([^]]+)\] \[([^]]+)\] ([^\n]*)(?:\n|$)')  # 匹配新版日志第一行
 LOG_PATTERN = re.compile(r'\n\[([^]]+)\] \[([^]]+)\] \[([^]]+)\] ([^\n]*)(?:\n|$)')  # 匹配新版日志行
+NEW_LINE_PATTERN = re.compile(r'^\[([^]]+)\] \[([^]]+)\] \[([^]]+)\] ([^\n]*)$')  # 匹配新版单行日志
 LEGACY_HEADER_PATTERN = re.compile(r'^\[([^]]+)\] \[([^]]+)\] ([^\n]+)$')  # 匹配旧版日志头
 TASK_BEGIN_PATTERN = re.compile(r'^配置组 "([^"]*)" 加载完成，共(\d+)个脚本，开始执行$')  # 匹配配置组开始
 
@@ -59,17 +60,17 @@ class LogDataManager:
         - 新格式: [时间] [级别] [类名] 消息
         - 旧格式: [时间] [级别] [类名]\\n消息
         """
-        matches = LOG_PATTERN.findall(log_content)
-        first_line_match = FIRST_LINE_PATTERN.match(log_content)
-        if first_line_match:
-            matches = [first_line_match.groups()] + matches
-            return matches
-
-        legacy_matches: List[Tuple[str, str, str, str]] = []
+        parsed_matches: List[Tuple[str, str, str, str]] = []
         lines = log_content.splitlines()
         i = 0
         while i < len(lines):
             line = lines[i].strip('\r')
+            new_line_match = NEW_LINE_PATTERN.match(line)
+            if new_line_match:
+                parsed_matches.append(new_line_match.groups())
+                i += 1
+                continue
+
             header_match = LEGACY_HEADER_PATTERN.match(line)
             if not header_match:
                 i += 1
@@ -82,7 +83,7 @@ class LogDataManager:
                     details = next_line
                     i += 1
 
-            legacy_matches.append((
+            parsed_matches.append((
                 header_match.group(1),
                 header_match.group(2),
                 header_match.group(3),
@@ -90,7 +91,7 @@ class LogDataManager:
             ))
             i += 1
 
-        return legacy_matches
+        return parsed_matches
 
     def parse_log(self, log_content: str, date_str: str) -> LogAnalysisResult:
         """

--- a/release/app/infrastructure/manager.py
+++ b/release/app/infrastructure/manager.py
@@ -17,8 +17,9 @@ logger = logging.getLogger('BetterGI初始化')
 FORBIDDEN_ITEMS = ['调查', '直接拾取']
 
 # 预编译正则表达式
-FIRST_LINE_PATTERN = re.compile(r'^\[([^]]+)\] \[([^]]+)\] \[([^]]+)\] ([^\n]*)(?:\n|$)')  # 匹配日志第一行
-LOG_PATTERN = re.compile(r'\n\[([^]]+)\] \[([^]]+)\] \[([^]]+)\] ([^\n]*)(?:\n|$)')  # 匹配日志行
+FIRST_LINE_PATTERN = re.compile(r'^\[([^]]+)\] \[([^]]+)\] \[([^]]+)\] ([^\n]*)(?:\n|$)')  # 匹配新版日志第一行
+LOG_PATTERN = re.compile(r'\n\[([^]]+)\] \[([^]]+)\] \[([^]]+)\] ([^\n]*)(?:\n|$)')  # 匹配新版日志行
+LEGACY_HEADER_PATTERN = re.compile(r'^\[([^]]+)\] \[([^]]+)\] ([^\n]+)$')  # 匹配旧版日志头
 TASK_BEGIN_PATTERN = re.compile(r'^配置组 "([^"]*)" 加载完成，共(\d+)个脚本，开始执行$')  # 匹配配置组开始
 
 
@@ -52,6 +53,45 @@ class LogDataManager:
         # 今天的日期字符串，用于排除今天的数据存储
         self.today_str = date.today().strftime('%Y%m%d')
     
+    def _extract_log_entries(self, log_content: str) -> List[Tuple[str, str, str, str]]:
+        """
+        兼容解析日志行：
+        - 新格式: [时间] [级别] [类名] 消息
+        - 旧格式: [时间] [级别] [类名]\\n消息
+        """
+        matches = LOG_PATTERN.findall(log_content)
+        first_line_match = FIRST_LINE_PATTERN.match(log_content)
+        if first_line_match:
+            matches = [first_line_match.groups()] + matches
+            return matches
+
+        legacy_matches: List[Tuple[str, str, str, str]] = []
+        lines = log_content.splitlines()
+        i = 0
+        while i < len(lines):
+            line = lines[i].strip('\r')
+            header_match = LEGACY_HEADER_PATTERN.match(line)
+            if not header_match:
+                i += 1
+                continue
+
+            details = ''
+            if i + 1 < len(lines):
+                next_line = lines[i + 1]
+                if not next_line.startswith('['):
+                    details = next_line
+                    i += 1
+
+            legacy_matches.append((
+                header_match.group(1),
+                header_match.group(2),
+                header_match.group(3),
+                details
+            ))
+            i += 1
+
+        return legacy_matches
+
     def parse_log(self, log_content: str, date_str: str) -> LogAnalysisResult:
         """
         解析日志内容，提取日志类型、交互物品等信息，并统计相关信息。
@@ -64,10 +104,7 @@ class LogDataManager:
         Returns:
             LogAnalysisResult: 包含解析结果的分析结果对象
         """
-        matches = LOG_PATTERN.findall(log_content)
-        first_line_match = FIRST_LINE_PATTERN.match(log_content)
-        if first_line_match:
-            matches = [first_line_match.groups()] + matches
+        matches = self._extract_log_entries(log_content)
 
         item_count = {}
         items = []

--- a/release/tests/test_infra.py
+++ b/release/tests/test_infra.py
@@ -107,6 +107,30 @@ class TestLogDataManager(unittest.TestCase):
         self.assertEqual(len(result.items), 1)
         self.assertEqual(result.items[0].name, "测试物品")
         self.assertEqual(result.items[0].config_group, "测试组")
+
+    def test_parse_log_legacy_multiline_format(self):
+        """
+        测试旧版多行日志格式兼容解析。
+        旧格式示例：
+        [12:00:00.000] [INFO] [TestClass]
+        配置组 "测试组" 加载完成，共1个脚本，开始执行
+        """
+        legacy_log_content = '''[12:00:00.000] [INFO] [TestClass]
+配置组 "测试组" 加载完成，共1个脚本，开始执行
+[12:01:00.000] [INFO] [TestClass]
+交互或拾取："旧格式物品"
+[12:02:00.000] [INFO] [TestClass]
+配置组 "测试组" 执行结束
+'''
+
+        result = self.log_manager.parse_log(legacy_log_content, "20250101")
+
+        self.assertIsNotNone(result)
+        self.assertIn("旧格式物品", result.item_count)
+        self.assertEqual(result.item_count["旧格式物品"], 1)
+        self.assertEqual(len(result.items), 1)
+        self.assertEqual(result.items[0].name, "旧格式物品")
+        self.assertEqual(result.items[0].config_group, "测试组")
     
     def test_read_log_file_not_found(self):
         """

--- a/release/tests/test_infra.py
+++ b/release/tests/test_infra.py
@@ -131,6 +131,31 @@ class TestLogDataManager(unittest.TestCase):
         self.assertEqual(len(result.items), 1)
         self.assertEqual(result.items[0].name, "旧格式物品")
         self.assertEqual(result.items[0].config_group, "测试组")
+
+    def test_parse_log_mixed_new_and_legacy_format(self):
+        """
+        测试新旧日志格式混用时的兼容解析。
+        预期同时解析：
+        - 新格式（单行）
+        - 旧格式（表头 + 下一行详情）
+        """
+        mixed_log_content = '''[12:00:00.000] [INFO] [TestClass] 配置组 "混合组" 加载完成，共2个脚本，开始执行
+[12:01:00.000] [INFO] [TestClass]
+交互或拾取："旧格式物品A"
+[12:02:00.000] [INFO] [TestClass] 交互或拾取："新格式物品B"
+[12:03:00.000] [INFO] [TestClass] 配置组 "混合组" 执行结束
+'''
+
+        result = self.log_manager.parse_log(mixed_log_content, "20250101")
+
+        self.assertIsNotNone(result)
+        self.assertIn("旧格式物品A", result.item_count)
+        self.assertIn("新格式物品B", result.item_count)
+        self.assertEqual(result.item_count["旧格式物品A"], 1)
+        self.assertEqual(result.item_count["新格式物品B"], 1)
+        self.assertEqual(len(result.items), 2)
+        self.assertEqual(result.items[0].config_group, "混合组")
+        self.assertEqual(result.items[1].config_group, "混合组")
     
     def test_read_log_file_not_found(self):
         """


### PR DESCRIPTION
### Motivation
- 保持對歷史日誌的向後相容性，支援舊版多行日誌格式以避免舊資料解析失敗。 
- 避免 `/api/stream` 路由出現半套推流管理邏輯，統一使用同一個管理器以簡化生命週期與資源釋放。 

### Description
- 新增 `_extract_log_entries` 在 `LogDataManager` 中以同時支援新版單行格式與舊版「表頭一行 + 內容下一行」多行格式，並將 `parse_log` 改為使用該入口函數以統一解析流程（修改檔案：`release/app/infrastructure/manager.py`）。
- 新增舊版日誌頭的正則 `LEGACY_HEADER_PATTERN`，並在解析時正確組合 header 與下一行內容以還原 `details` 欄位（修改檔案：`release/app/infrastructure/manager.py`）。
- 將 `/api/stream`、`/api/stream/info`、`/api/stream/stop` 全部改為透過 `stream_manager.get_controller` / `stream_manager.stop_controller` 操作，並新增 `_resolve_stream_target_app` 用於解析或自動推斷 `app`（修改檔案：`release/app/api/views.py`）。

### Testing
- 新增回歸測試 `test_parse_log_legacy_multiline_format`（檔案：`release/tests/test_infra.py`）以覆蓋舊多行格式的配置組與拾取物品抽取。 
- 執行單元測試 `python -m unittest tests.test_infra -v`，所有測試共 7 項通過（OK）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee11c1dbdc8330af389c2ced3430d4)